### PR TITLE
Refactor main.py for CLI and reusability

### DIFF
--- a/examples/alanine_dipeptide/ad_setup.yml
+++ b/examples/alanine_dipeptide/ad_setup.yml
@@ -1,0 +1,37 @@
+keep_atoms: backbone
+
+network_config:
+  n_layers: [2, 3, 4, 5]
+  batch_size: [5000]
+  optimizer: [adam]
+  epochs: [500]
+
+layer_config:
+  layer_type:
+    - dense
+    - dropout
+    - batch_norm
+    - batch_norm_dropout
+  n_nodes: [4, 8, 16, 32]
+  activation:
+    - relu
+    - selu
+    - tanh
+    - elu
+    - sigmoid
+    - linear
+    - exponential
+  dropout: [0.1, 0.2]
+
+optimizer:
+  pop_size: 50
+  train_verbose: 0
+  reject_select_chance: 0.05
+  retain: 0.02
+  early_stopping: true
+  mutation_rate: 0.1
+  penalty: 0.15
+  parent_frac: 0.1
+  cache: true
+  train_chance: 0.5
+  val_split: 0.3

--- a/examples/alanine_dipeptide/main.py
+++ b/examples/alanine_dipeptide/main.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 import random
 import os
+import yaml
 import pandas as pd
 import mdtraj as md
 import tensorflow as tf
@@ -14,54 +15,77 @@ from fabulous import Optimizer
 # os.environ['CUDA_VISIBLE_DEVICES'] = '-1'
 
 # If using GPU, use dynamic memory allocation
-gpus = tf.config.list_physical_devices('GPU')
-if gpus:
-    try:
-        # Currently, memory growth needs to be the same across GPUs
-        for gpu in gpus:
-            tf.config.experimental.set_memory_growth(gpu, True)
-        logical_gpus = tf.config.experimental.list_logical_devices('GPU')
-        print(len(gpus), "Physical GPUs,", len(logical_gpus), "Logical GPUs")
-    except RuntimeError as e:
-        # Memory growth must be set before GPUs have been initialized
-        print(e)
-
-random.seed(10)
+def check_gpus():
+    gpus = tf.config.list_physical_devices('GPU')
+    if gpus:
+        try:
+            # Currently, memory growth needs to be the same across GPUs
+            for gpu in gpus:
+                tf.config.experimental.set_memory_growth(gpu, True)
+            logical_gpus = tf.config.experimental.list_logical_devices('GPU')
+            print(len(gpus), "Physical GPUs,", len(logical_gpus),
+                  "Logical GPUs")
+        except RuntimeError as e:
+            # Memory growth must be set before GPUs have been initialized
+            print(e)
 
 # loading the CV-data
-print("Loading CV data...")
-fns = glob("./data/AD/CV/CV_data/*")
-cv_data = [read_CV(fn) for fn in fns]
-cv_data = pd.concat(cv_data, ignore_index=True)
-cv_data = cv_data.drop(['time'], axis=1)
-# min-max normalization
-cv_data = (cv_data - cv_data.min()) / (cv_data.max() - cv_data.min())
-print(cv_data.describe())
-print(cv_data.columns)
+def prepare_cv(cv_dir):
+    """
+    Returns
+    -------
+    pandas.DataFrame
+        single dataframe with all CV information
+    """
+    print("Loading CV data...")
+    fns = glob(os.path.join(cv_dir, "*"))
+    cv_data = [read_CV(fn) for fn in fns]
+    cv_data = pd.concat(cv_data, ignore_index=True)
+    cv_data = cv_data.drop(['time'], axis=1)
+    return cv_data
 
-cv_train, cv_test = train_test_split(cv_data, train_size=0.7, shuffle=True)
-print(cv_train)
-print(cv_test)
+def finish_cv_data(cv_data, train_size=0.7):
+    # min-max normalization
+    cv_data = (cv_data - cv_data.min()) / (cv_data.max() - cv_data.min())
+    print(cv_data.describe())
+    print(cv_data.columns)
+    cv_train, cv_test = train_test_split(cv_data, train_size=train_size,
+                                         shuffle=True)
+    print(cv_train)
+    print(cv_test)
+    return cv_train, cv_test
 
 # loading the TPS-data
-print("Loading TPS data...")
-fns = glob("./data/AD/TPS/trjs/*")
-ref = md.load("./data/AD/c7ax_input.pdb")
-backbone = [atom.index for atom in ref.top.atoms if atom.is_backbone]
-md_data = []
-for i, fn in enumerate(fns):
-    md_data.append(read_MD(fn, ref, backbone))
-    if i % 100 == 0:
-        print(i)
-md_data = pd.concat(md_data, ignore_index=True)
-print(md_data.describe())
-print(md_data.head())
+def prepare_md(md_dir, ref_file, keep_atoms):
+    """
+    Returns
+    -------
+    pandas.DataFrame
+        single dataframe with all (aligned) posisiton of selected atoms
+    """
+    print("Loading TPS data...")
+    fns = glob(os.path.join(md_dir, "*"))
+    ref = md.load(ref_file)
+    if isinstance(keep_atoms, str):
+        keep_atoms = ref.topology.select(keep_atoms)
+    md_data = []
+    for i, fn in enumerate(fns):
+        md_data.append(read_MD(fn, ref, keep_atoms))
+        if i % 100 == 0:
+            print(i)
+    md_data = pd.concat(md_data, ignore_index=True)
+    return md_data
 
-md_train = md_data.reindex(cv_train.index)
-md_test = md_data.reindex(cv_test.index)
+def finish_md_data(md_data, cv_train, cv_test):
+    print(md_data.describe())
+    print(md_data.head())
+
+    md_train = md_data.reindex(cv_train.index)
+    md_test = md_data.reindex(cv_test.index)
+    return md_train, md_test
 
 # constraints for architecture optimization
-param_constraints_input = {
+PARAM_CONSTRAINT_DEFAULTS = {
     'network_config': {'n_layers': [2, 3, 4, 5],
                        'batch_size': [5000],
                        'optimizer': ['adam'],
@@ -72,31 +96,83 @@ param_constraints_input = {
                      'n_nodes': [4, 8, 16, 32],
                      'activation': ['relu', 'selu', 'tanh', 'elu', 'sigmoid', 'linear', 'exponential'],
                      'dropout': [0.1, 0.2]
-                     },
-
-    'io_config': {'input_shape': [7],
-                  'inputs': cv_train.columns.tolist(),
-                  'output_shape': [md_train.shape[1]],
-                  'outputs': ['custom']
-                  }
+                    },
 }
 
-n_gen = 50
-run = '1'
-if not os.path.exists('./results'):
-    os.makedirs('./results')
+def io_config(cv_train, md_train):
+    cols = cv_train.columns
+    return {
+        'input_shape': [len(cols)],
+        'inputs': cols.tolist(),
+        'output_shape': [md_train.shape[1]],
+        'outputs': ['custom']
+    }
 
-optimizer = Optimizer(param_constraints_input, build_model, cv_train, log_dir="./results/run_{}".format(run),
-                      pop_size=50, train_verbose=0, reject_select_chance=0.05, retain=0.02, early_stopping=True,
-                      mutation_rate=0.1, penalty=0.15, parent_frac=0.1, cache=True, train_chance=0.5,
-                      test_data=cv_test, val_split=0.3, y_train=md_train, y_test=md_test)
+def load_param_dict(yaml_file):
+    with open(yaml_file, mode='r') as f:
+        param_dict = yaml.load(f, Loader=yaml.FullLoader)
 
-pop = optimizer.create_pop()
+    optimizer_params = param_dict.pop('optimizer', {})
+    keep_atoms = param_dict.pop('keep_atoms')
+    print(optimizer_params)
+    return param_dict, optimizer_params, keep_atoms
 
-gen_scores = []
-for i in range(0, n_gen):
-    pop = optimizer.evolve(pop)
-    current_score = optimizer.get_gen_scores(i)
-    optimizer.pickle_gen(i)
-    gen_scores.append(current_score)
-    optimizer.pickle_all_gen()
+def run_fabulous(cv_train, cv_test, md_train, md_test,
+                 param_constraints_input, optimizer_params, n_gen=50,
+                 results_dir="results", label="1"):
+    keys = [key for key in PARAM_CONSTRAINT_DEFAULTS
+            if key in param_constraints_input]
+    # make a copy of the defaults
+    param_constraints = dict(PARAM_CONSTRAINT_DEFAULTS)
+    for key in keys:
+        param_constraints[key].update(param_constraints_input[key])
+
+    param_constraints['io_config'] = io_config(cv_train, md_train)
+
+    if not os.path.exists(results_dir):
+        os.makedirs(results_dir)
+
+    log_dir = os.path.join(results_dir, "run_{}".format(label))
+
+    optimizer = Optimizer(
+        param_constraints, build_model, cv_train, log_dir=log_dir,
+        test_data=cv_test, y_train=md_train, y_test=md_test,
+        **optimizer_params
+    )
+
+    pop = optimizer.create_pop()
+
+    gen_scores = []
+    for i in range(n_gen):
+        pop = optimizer.evolve(pop)
+        current_score = optimizer.get_gen_scores(i)
+        optimizer.pickle_gen(i)
+        gen_scores.append(current_score)
+        optimizer.pickle_all_gen()
+
+
+def main(cv_dir, md_dir, ref_file, yaml_file, n_gen, results_dir, label):
+    check_gpus()
+    param_constraints_input, optimizer_params, keep_atoms = \
+            load_param_dict(yaml_file)
+    cv_data = prepare_cv(cv_dir)  # this will be different for OPS
+    cv_train, cv_test = finish_cv_data(cv_data)
+    md_data = prepare_md(md_dir, ref_file, keep_atoms)  # and this
+    md_train, md_test = finish_md_data(md_data, cv_train, cv_test)
+    run_fabulous(cv_train, cv_test, md_train, md_test,
+                 param_constraints_input, optimizer_params, n_gen,
+                 results_dir, label)
+
+
+if __name__ == "__main__":
+    # hard coded for now, but better to take from a argparse parser
+    cv_dir = "./data/AD/CV/CV_data/"
+    md_dir = "./data/AD/TPS/trjs/"
+    ref_file = "./data/AD/c7ax_input.pdb"
+    yaml_file = "ad_setup.yml"
+    n_gen = 50
+    results_dir = "results"
+    label = "2"
+    keep_atoms = "backbone"
+    random.seed(10)
+    main(cv_dir, md_dir, ref_file, yaml_file, n_gen, results_dir, label)


### PR DESCRIPTION
This refactors `main.py` in the AD example so that parts of it can more easily be moved into the package and thus reused by client code/turned into a CLI. A couple of comments in the `main()` function highlight the parts that would be different for OPS — otherwise, the outline of that function will be pretty much the same for the OPS CLI. (Already up to the concatenated `cv_data` and `md_data` in https://github.com/dwhswenson/fabulous-paths/pull/6.)

The design goal has been to keep the overall interface small (few functions that need to be called by the CLI code), while also using FABULOUS to handle as much as possible, so the user experience is similar in either case.

Most of the ML parameters have been moved to a configuration file. The config file I created matches the example, but anything that also matches defaults could be removed from the config file. I currently put `keep_atoms` in the config file, but I think I have a better way of handling that on the way.

This adds the requirement of the `pyyaml` package (imported under `yaml`, pip/conda install `pyyaml`) to parse the configuration file.

It seems to still work (at least, I started a second gen on my laptop before I stopped it).